### PR TITLE
Implement `info` API -  `/api/v1/version` endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+reqwest = { version = "0.12.12", features = ["blocking"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }

--- a/examples/info-api.rs
+++ b/examples/info-api.rs
@@ -1,0 +1,12 @@
+use argoflows::api::info;
+use argoflows::config::Config;
+
+fn main() {
+    let token = std::env::var("ARGO_TOKEN").expect("the ARGO_TOKEN env variable must be set");
+
+    let cfg = Config::new(token);
+    match info::get_version(&cfg) {
+        Ok(v) => println!("{:?}\n", v),
+        Err(e) => eprintln!("failed to get version: {:?}", e),
+    }
+}

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,0 +1,30 @@
+use crate::config::Config;
+use crate::error::{info::GetVersionError, Error};
+use crate::types::{info::Version, ResponseContent};
+
+pub fn get_version(config: &Config) -> Result<Version, Error<GetVersionError>> {
+    let uri = format!("{}/api/v1/version", config.base_path);
+
+    let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
+
+    if let Some(bearer_token) = &config.bearer_token {
+        req_builder = req_builder.bearer_auth(bearer_token);
+    }
+
+    let req = req_builder.build()?;
+    let resp = config.client.execute(req)?;
+    let status = resp.status();
+    let content = resp.text()?;
+
+    if !status.is_client_error() && !status.is_server_error() {
+        serde_json::from_str(&content).map_err(Error::from)
+    } else {
+        let entity: Option<GetVersionError> = serde_json::from_str(&content).ok();
+        let error = ResponseContent {
+            status,
+            content,
+            entity,
+        };
+        Err(Error::Response(error))
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod info;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,23 @@
+use reqwest::blocking as reqwest;
+
+const DEFAULT_BASE_PATH: &str = "https://localhost:2746";
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub base_path: String,
+    pub client: reqwest::Client,
+    pub bearer_token: Option<String>,
+}
+
+impl Config {
+    pub fn new(bearer_token: String) -> Self {
+        Config {
+            base_path: DEFAULT_BASE_PATH.to_owned(),
+            bearer_token: Some(bearer_token),
+            client: reqwest::Client::builder()
+                .danger_accept_invalid_certs(true)
+                .build()
+                .expect("failed to create a reqwest client"),
+        }
+    }
+}

--- a/src/error/info.rs
+++ b/src/error/info.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+/// Struct for typed errors of method [`api::info::get_version`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetVersionError {
+    DefaultResponse(super::GatewayRuntimeError),
+    UnknownValue(serde_json::Value),
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,76 @@
+use std::error;
+use std::fmt;
+
+use reqwest;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use serde_with::serde_as;
+
+use crate::types::ResponseContent;
+
+#[derive(Debug)]
+pub enum Error<T> {
+    Reqwest(reqwest::Error),
+    Serde(serde_json::Error),
+    Io(std::io::Error),
+    Response(ResponseContent<T>),
+}
+
+impl<T> fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (module, e) = match self {
+            Error::Reqwest(e) => ("reqwest", e.to_string()),
+            Error::Serde(e) => ("serde", e.to_string()),
+            Error::Io(e) => ("IO", e.to_string()),
+            Error::Response(e) => ("response", format!("status code {}", e.status)),
+        };
+        write!(f, "error in {}: {}", module, e)
+    }
+}
+
+impl<T: fmt::Debug> error::Error for Error<T> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        Some(match self {
+            Error::Reqwest(e) => e,
+            Error::Serde(e) => e,
+            Error::Io(e) => e,
+            Error::Response(_) => return None,
+        })
+    }
+}
+
+impl<T> From<serde_json::Error> for Error<T> {
+    fn from(e: serde_json::Error) -> Self {
+        Error::Serde(e)
+    }
+}
+
+impl<T> From<reqwest::Error> for Error<T> {
+    fn from(e: reqwest::Error) -> Self {
+        Error::Reqwest(e)
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GatewayRuntimeError {
+    #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+    #[serde(rename = "details", skip_serializing_if = "Option::is_none")]
+    pub details: Option<Vec<GoogleProtobufAny>>,
+    #[serde(rename = "error", skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[serde_as]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GoogleProtobufAny {
+    #[serde(rename = "type_url", skip_serializing_if = "Option::is_none")]
+    pub type_url: Option<String>,
+    #[serde_as(as = "Option<serde_with::base64::Base64>")]
+    #[serde(rename = "value", skip_serializing_if = "Option::is_none")]
+    pub value: Option<Vec<u8>>,
+}
+
+pub mod info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod api;
+pub mod config;
+pub mod error;
+pub mod types;

--- a/src/types/info.rs
+++ b/src/types/info.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Version {
+    #[serde(rename = "buildDate")]
+    pub build_date: String,
+    #[serde(rename = "compiler")]
+    pub compiler: String,
+    #[serde(rename = "gitCommit")]
+    pub git_commit: String,
+    #[serde(rename = "gitTag")]
+    pub git_tag: String,
+    #[serde(rename = "gitTreeState")]
+    pub git_tree_state: String,
+    #[serde(rename = "goVersion")]
+    pub go_version: String,
+    #[serde(rename = "platform")]
+    pub platform: String,
+    #[serde(rename = "version")]
+    pub version: String,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,10 @@
+use reqwest;
+
+#[derive(Debug)]
+pub struct ResponseContent<T> {
+    pub status: reqwest::StatusCode,
+    pub content: String,
+    pub entity: Option<T>,
+}
+
+pub mod info;


### PR DESCRIPTION
In favour of #3 