### PR TITLE
Add config builder for argoflows

### DIFF
--- a/examples/info-api.rs
+++ b/examples/info-api.rs
@@ -4,7 +4,12 @@ use argoflows::config::Config;
 fn main() {
     let token = std::env::var("ARGO_TOKEN").expect("the ARGO_TOKEN env variable must be set");
 
-    let cfg = Config::new(token);
+    let cfg = Config::builder()
+        .bearer_token(&token)
+        .danger_accept_invalid_certs(true)
+        .build();
+    let cfg = cfg.expect("failed to create client config");
+
     match info::get_version(&cfg) {
         Ok(v) => println!("{:?}\n", v),
         Err(e) => eprintln!("failed to get version: {:?}", e),

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -3,7 +3,7 @@ use crate::error::{info::GetVersionError, Error};
 use crate::types::{info::Version, ResponseContent};
 
 pub fn get_version(config: &Config) -> Result<Version, Error<GetVersionError>> {
-    let uri = format!("{}/api/v1/version", config.base_path);
+    let uri = format!("{}/api/v1/version", config.host);
 
     let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
 


### PR DESCRIPTION
Fixes: #6 

Ended up with the following structure:

```rust
let cfg = Config::builder()		// creates a client builder
    .bearer_token(&token)		// sets a bearer_token for the client
    .danger_accept_invalid_certs(true)	// allows accepting invalid certs to connect over HTTPS
    .build(); // builds the client and returns Result<Config, reqwest::Error>

let cfg = cfg.expect("failed to create client config");
let _ = info::get_version(&cfg);
```