### PR TITLE
Implement `InfoService` endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-reqwest = { version = "0.12.12", features = ["blocking"] }
+reqwest = { version = "0.12.12", features = ["json", "blocking"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }

--- a/examples/info-api.rs
+++ b/examples/info-api.rs
@@ -10,6 +10,11 @@ fn main() {
         .build();
     let cfg = cfg.expect("failed to create client config");
 
+    match info::get_info(&cfg) {
+        Ok(r) => println!("{:?}\n", r),
+        Err(e) => eprintln!("failed to get info: {:?}", e),
+    }
+
     match info::get_version(&cfg) {
         Ok(v) => println!("{:?}\n", v),
         Err(e) => eprintln!("failed to get version: {:?}", e),

--- a/examples/info-api.rs
+++ b/examples/info-api.rs
@@ -1,5 +1,6 @@
 use argoflows::api::info;
 use argoflows::config::Config;
+use argoflows::types::info::CollectEventRequest;
 
 fn main() {
     let token = std::env::var("ARGO_TOKEN").expect("the ARGO_TOKEN env variable must be set");
@@ -9,6 +10,20 @@ fn main() {
         .danger_accept_invalid_certs(true)
         .build();
     let cfg = cfg.expect("failed to create client config");
+
+    let payload = r#"{
+        "type": "custom-event",
+        "source": "ci-pipeline",
+        "data": {
+            "workflow": "event-driven-workflow",
+            "trigger": "build-success",
+            "message": "Build completed successfully!"
+        }
+    }"#;
+    match info::collect_event(&cfg, CollectEventRequest::new(payload)) {
+        Ok(r) => println!("{:?}\n", r),
+        Err(e) => eprintln!("failed to get info: {:?}", e),
+    }
 
     match info::get_info(&cfg) {
         Ok(r) => println!("{:?}\n", r),

--- a/examples/info-api.rs
+++ b/examples/info-api.rs
@@ -15,6 +15,11 @@ fn main() {
         Err(e) => eprintln!("failed to get info: {:?}", e),
     }
 
+    match info::get_user_info(&cfg) {
+        Ok(r) => println!("{:?}\n", r),
+        Err(e) => eprintln!("failed to get user info: {:?}", e),
+    }
+
     match info::get_version(&cfg) {
         Ok(v) => println!("{:?}\n", v),
         Err(e) => eprintln!("failed to get version: {:?}", e),

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,12 +1,45 @@
+use serde_json;
+
 use crate::config::Config;
 use crate::error::{
-    info::{GetInfoError, GetVersionError, UserInfoError},
+    info::{CollectEventError, GetInfoError, GetVersionError, UserInfoError},
     Error,
 };
 use crate::types::{
-    info::{InfoResponse, UserInfoResponse, Version},
+    info::{CollectEventRequest, InfoResponse, UserInfoResponse, Version},
     ResponseContent,
 };
+
+pub fn collect_event(
+    config: &Config,
+    body: CollectEventRequest,
+) -> Result<serde_json::Value, Error<CollectEventError>> {
+    let uri = format!("{}/api/v1/tracking/event", config.host);
+    let mut req_builder = config.client.request(reqwest::Method::POST, uri.as_str());
+
+    if let Some(bearer_token) = &config.bearer_token {
+        req_builder = req_builder.bearer_auth(bearer_token);
+    }
+
+    req_builder = req_builder.json(&body);
+    let req = req_builder.build()?;
+    let res = config.client.execute(req)?;
+    let status = res.status();
+    let content = res.text()?;
+
+    if !status.is_client_error() && !status.is_server_error() {
+        serde_json::from_str(&content).map_err(Error::from)
+    } else {
+        let entity: Option<CollectEventError> = serde_json::from_str(&content).ok();
+        let err = ResponseContent {
+            status,
+            content,
+            entity,
+        };
+
+        Err(Error::Response(err))
+    }
+}
 
 pub fn get_info(config: &Config) -> Result<InfoResponse, Error<GetInfoError>> {
     let uri = format!("{}/api/v1/info", config.host);

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,10 +1,10 @@
 use crate::config::Config;
 use crate::error::{
-    info::{CollectEventError, GetInfoError, GetVersionError, UserInfoError},
+    info::{CollectEventError, GetInfoError, GetUserInfoError, GetVersionError},
     Error,
 };
 use crate::types::{
-    info::{CollectEventRequest, InfoResponse, UserInfoResponse, Version},
+    info::{CollectEventRequest, Info, UserInfo, Version},
     ResponseContent,
 };
 
@@ -39,7 +39,7 @@ pub fn collect_event(
     }
 }
 
-pub fn get_info(config: &Config) -> Result<InfoResponse, Error<GetInfoError>> {
+pub fn get_info(config: &Config) -> Result<Info, Error<GetInfoError>> {
     let uri = format!("{}/api/v1/info", config.host);
     let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
 
@@ -66,7 +66,7 @@ pub fn get_info(config: &Config) -> Result<InfoResponse, Error<GetInfoError>> {
     }
 }
 
-pub fn get_user_info(config: &Config) -> Result<UserInfoResponse, Error<UserInfoError>> {
+pub fn get_user_info(config: &Config) -> Result<UserInfo, Error<GetUserInfoError>> {
     let uri = format!("{}/api/v1/userinfo", config.host);
     let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
 
@@ -82,7 +82,7 @@ pub fn get_user_info(config: &Config) -> Result<UserInfoResponse, Error<UserInfo
     if !status.is_client_error() && !status.is_server_error() {
         serde_json::from_str(&content).map_err(Error::from)
     } else {
-        let entity: Option<UserInfoError> = serde_json::from_str(&content).ok();
+        let entity: Option<GetUserInfoError> = serde_json::from_str(&content).ok();
         let err = ResponseContent {
             status,
             content,

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,5 +1,3 @@
-use serde_json;
-
 use crate::config::Config;
 use crate::error::{
     info::{CollectEventError, GetInfoError, GetVersionError, UserInfoError},

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,10 +1,10 @@
 use crate::config::Config;
 use crate::error::{
-    info::{GetInfoError, GetVersionError},
+    info::{GetInfoError, GetVersionError, UserInfoError},
     Error,
 };
 use crate::types::{
-    info::{InfoResponse, Version},
+    info::{InfoResponse, UserInfoResponse, Version},
     ResponseContent,
 };
 
@@ -25,6 +25,33 @@ pub fn get_info(config: &Config) -> Result<InfoResponse, Error<GetInfoError>> {
         serde_json::from_str(&content).map_err(Error::from)
     } else {
         let entity: Option<GetInfoError> = serde_json::from_str(&content).ok();
+        let err = ResponseContent {
+            status,
+            content,
+            entity,
+        };
+
+        Err(Error::Response(err))
+    }
+}
+
+pub fn get_user_info(config: &Config) -> Result<UserInfoResponse, Error<UserInfoError>> {
+    let uri = format!("{}/api/v1/userinfo", config.host);
+    let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
+
+    if let Some(bearer_token) = &config.bearer_token {
+        req_builder = req_builder.bearer_auth(bearer_token);
+    }
+
+    let req = req_builder.build()?;
+    let res = config.client.execute(req)?;
+    let status = res.status();
+    let content = res.text()?;
+
+    if !status.is_client_error() && !status.is_server_error() {
+        serde_json::from_str(&content).map_err(Error::from)
+    } else {
+        let entity: Option<UserInfoError> = serde_json::from_str(&content).ok();
         let err = ResponseContent {
             status,
             content,

--- a/src/api/info.rs
+++ b/src/api/info.rs
@@ -1,6 +1,39 @@
 use crate::config::Config;
-use crate::error::{info::GetVersionError, Error};
-use crate::types::{info::Version, ResponseContent};
+use crate::error::{
+    info::{GetInfoError, GetVersionError},
+    Error,
+};
+use crate::types::{
+    info::{InfoResponse, Version},
+    ResponseContent,
+};
+
+pub fn get_info(config: &Config) -> Result<InfoResponse, Error<GetInfoError>> {
+    let uri = format!("{}/api/v1/info", config.host);
+    let mut req_builder = config.client.request(reqwest::Method::GET, uri.as_str());
+
+    if let Some(bearer_token) = &config.bearer_token {
+        req_builder = req_builder.bearer_auth(bearer_token);
+    }
+
+    let req = req_builder.build()?;
+    let res = config.client.execute(req)?;
+    let status = res.status();
+    let content = res.text()?;
+
+    if !status.is_client_error() && !status.is_server_error() {
+        serde_json::from_str(&content).map_err(Error::from)
+    } else {
+        let entity: Option<GetInfoError> = serde_json::from_str(&content).ok();
+        let err = ResponseContent {
+            status,
+            content,
+            entity,
+        };
+
+        Err(Error::Response(err))
+    }
+}
 
 pub fn get_version(config: &Config) -> Result<Version, Error<GetVersionError>> {
     let uri = format!("{}/api/v1/version", config.host);

--- a/src/error/info.rs
+++ b/src/error/info.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+/// struct for typed errors of method [`api::info::collect_event`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CollectEventError {
+    DefaultResponse(super::GatewayRuntimeError),
+    UnknownValue(serde_json::Value),
+}
+
 /// Struct for typed errors of method [`api::info::get_info`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/src/error/info.rs
+++ b/src/error/info.rs
@@ -19,7 +19,7 @@ pub enum GetInfoError {
 /// Struct for typed errors of method [`api::info::get_user_info`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum UserInfoError {
+pub enum GetUserInfoError {
     DefaultResponse(super::GatewayRuntimeError),
     UnknownValue(serde_json::Value),
 }

--- a/src/error/info.rs
+++ b/src/error/info.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+/// Struct for typed errors of method [`api::info::get_info`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetInfoError {
+    DefaultResponse(super::GatewayRuntimeError),
+    UnknownValue(serde_json::Value),
+}
+
 /// Struct for typed errors of method [`api::info::get_version`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/src/error/info.rs
+++ b/src/error/info.rs
@@ -8,6 +8,14 @@ pub enum GetInfoError {
     UnknownValue(serde_json::Value),
 }
 
+/// Struct for typed errors of method [`api::info::get_user_info`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum UserInfoError {
+    DefaultResponse(super::GatewayRuntimeError),
+    UnknownValue(serde_json::Value),
+}
+
 /// Struct for typed errors of method [`api::info::get_version`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/src/types/info.rs
+++ b/src/types/info.rs
@@ -15,7 +15,7 @@ impl CollectEventRequest {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
-pub struct InfoResponse {
+pub struct Info {
     #[serde(rename = "columns", skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<Column>>,
     #[serde(rename = "links", skip_serializing_if = "Option::is_none")]
@@ -29,7 +29,7 @@ pub struct InfoResponse {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
-pub struct UserInfoResponse {
+pub struct UserInfo {
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(rename = "emailVerified", skip_serializing_if = "Option::is_none")]

--- a/src/types/info.rs
+++ b/src/types/info.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CollectEventRequest {
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl CollectEventRequest {
+    pub fn new(name: &str) -> Self {
+        CollectEventRequest {
+            name: Some(name.to_owned()),
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InfoResponse {
     #[serde(rename = "columns", skip_serializing_if = "Option::is_none")]
     pub columns: Option<Vec<Column>>,

--- a/src/types/info.rs
+++ b/src/types/info.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct InfoResponse {
+    #[serde(rename = "columns", skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<Column>>,
+    #[serde(rename = "links", skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(rename = "managedNamespace", skip_serializing_if = "Option::is_none")]
+    pub managed_namespace: Option<String>,
+    #[serde(rename = "modals", skip_serializing_if = "Option::is_none")]
+    pub modals: Option<std::collections::HashMap<String, bool>>,
+    #[serde(rename = "navColor", skip_serializing_if = "Option::is_none")]
+    pub nav_color: Option<String>,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Version {
     #[serde(rename = "buildDate")]
     pub build_date: String,
@@ -18,4 +32,35 @@ pub struct Version {
     pub platform: String,
     #[serde(rename = "version")]
     pub version: String,
+}
+
+/// A custom `Column` that will be exposed in the Workflow List View.
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Column {
+    /// The key of the label or annotation, e.g., `workflows.argoproj.io/completed`.
+    #[serde(rename = "key")]
+    pub key: String,
+    /// The name of this column, e.g., `Workflow Completed`.
+    #[serde(rename = "name")]
+    pub name: String,
+    /// The type of this column, `label` or `annotation`.
+    #[serde(rename = "type")]
+    pub r#type: String,
+}
+
+/// A `Link` to another app.
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Link {
+    /// The name of the link, E.g. `Workflow Logs` or `Pod Logs`
+    #[serde(rename = "name")]
+    pub name: String,
+    /// `workflow`, `pod`, `pod-logs`, `event-source-logs`, `sensor-logs`, `workflow-list` or `chat`
+    #[serde(rename = "scope")]
+    pub scope: String,
+    /// The `URL` can contain `${metadata.namespace}`, `${metadata.name}`,
+    /// `${status.startedAt}`, `${status.finishedAt}` or any other element
+    /// in workflow yaml, e.g.
+    /// `${io.argoproj.workflow.v1alpha1.metadata.annotations.userDefinedKey}`
+    #[serde(rename = "url")]
+    pub url: String,
 }

--- a/src/types/info.rs
+++ b/src/types/info.rs
@@ -15,6 +15,29 @@ pub struct InfoResponse {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UserInfoResponse {
+    #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(rename = "emailVerified", skip_serializing_if = "Option::is_none")]
+    pub email_verified: Option<bool>,
+    #[serde(rename = "groups", skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(rename = "issuer", skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "serviceAccountName", skip_serializing_if = "Option::is_none")]
+    pub service_account_name: Option<String>,
+    #[serde(
+        rename = "serviceAccountNamespace",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_account_namespace: Option<String>,
+    #[serde(rename = "subject", skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Version {
     #[serde(rename = "buildDate")]
     pub build_date: String,


### PR DESCRIPTION
Fixes: #3 

- Implements the following endpoints for `api::info`:
  - [x] Implement the `/api/v1/info` `GET` endpoint
  - [x] Implement the `/api/v1/tracking/event` `POST` endpoint
  - [x] Implement the `/api/v1/userinfo` `GET` endpoint
- Adds example for each endpoint
